### PR TITLE
Stop start.R with an error if retrieveData stopped due to an error.

### DIFF
--- a/start.R
+++ b/start.R
@@ -67,8 +67,6 @@ stoppedWithError <- tryCatch({
   return(TRUE)
 })
 
-warnings()
-
 today <- format(Sys.time(), "%Y-%m-%d")
 
 # If this is an APT send bot message to mattermost in case the APT produced warnings or errors
@@ -86,5 +84,7 @@ if (isTRUE(grepl("APT", cfg$dev))) {
     writeLines(mattermostMessage, paste0("/p/projects/rd3mod/mattermost_bot/REMIND/APT-", today))
   }
 }
+
+if (stoppedWithError) stop("retrieveData stopped due to an error. Search the logfile for 'Error'")
 
 message(today, " Preprocessing done.\n\n")


### PR DESCRIPTION
With one of the latest PRs `retrieveData` has been put into an `try` block, causing the slurm mail to always report exit code 0, even if the pre-processing failed. Therefore, with this PR we trigger an error at the end of the script if `retrieveData` was deteced to stop by an error.