### PR TITLE
upgrade to renv 1.1.7

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,7 +1,9 @@
-local({
 # setting RENV_PATHS_LIBRARY ensures packages are installed into renv/library
 # for some reason this also has implications for symlinking into the global cache
 Sys.setenv(RENV_PATHS_LIBRARY = "renv/library")
+
+# do not check if library and renv.lock are in sync, because normally renv.lock does not exist
+options(renv.config.synchronized.check = FALSE)
 
 source("renv/activate.R")
 
@@ -9,10 +11,14 @@ if (!"https://rse.pik-potsdam.de/r/packages" %in% getOption("repos")) {
   options(repos = c(getOption("repos"), pik = "https://rse.pik-potsdam.de/r/packages"))
 }
 
-# bootstrapping, will only run once after remind is freshly cloned
+# bootstrapping, will only run once after this repo is freshly cloned
 if (isTRUE(rownames(installed.packages(priority = "NA")) == "renv")) {
   message("R package dependencies are not installed in this renv, installing now...")
-  renv::hydrate() # auto-detect and install all dependencies
+  renv::hydrate(prompt = FALSE, report = FALSE) # auto-detect and install all dependencies
   message("Finished installing R package dependencies.")
 }
-})
+
+# in case bootstrapping fails halfway, install piamenv and rely on requirement auto-fixing
+if (tryCatch(utils::packageVersion("piamenv") < "0.5.5", error = function(error) TRUE)) {
+  renv::install("piamenv", prompt = FALSE)
+}

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,8 @@
 local({
 
   # the requested version of renv
-  version <- "1.1.5"
+  version <- "1.1.7"
+  attr(version, "md5") <- NULL
   attr(version, "sha") <- NULL
 
   # the project directory
@@ -168,6 +169,16 @@ local({
     if (quiet)
       return(invisible())
   
+    # also check for config environment variables that should suppress messages
+    # https://github.com/rstudio/renv/issues/2214
+    enabled <- Sys.getenv("RENV_CONFIG_STARTUP_QUIET", unset = NA)
+    if (!is.na(enabled) && tolower(enabled) %in% c("true", "1"))
+      return(invisible())
+  
+    enabled <- Sys.getenv("RENV_CONFIG_SYNCHRONIZED_CHECK", unset = NA)
+    if (!is.na(enabled) && tolower(enabled) %in% c("false", "0"))
+      return(invisible())
+  
     msg <- sprintf(fmt, ...)
     cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
   
@@ -215,6 +226,16 @@ local({
     section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
   
+    # try to install renv from cache
+    md5 <- attr(version, "md5", exact = TRUE)
+    if (length(md5)) {
+      pkgpath <- renv_bootstrap_find(version)
+      if (length(pkgpath) && file.exists(pkgpath)) {
+        file.copy(pkgpath, library, recursive = TRUE)
+        return(invisible())
+      }
+    }
+  
     # attempt to download renv
     catf("- Downloading renv ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -240,7 +261,6 @@ local({
   
     # add empty line to break up bootstrapping from normal output
     catf("")
-  
     return(invisible())
   }
   
@@ -257,12 +277,20 @@ local({
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
     if (!is.na(repos)) {
   
-      # check for RSPM; if set, use a fallback repository for renv
-      rspm <- Sys.getenv("RSPM", unset = NA)
-      if (identical(rspm, repos))
-        repos <- c(RSPM = rspm, CRAN = cran)
+      # split on ';' if present
+      parts <- strsplit(repos, ";", fixed = TRUE)[[1L]]
   
-      return(repos)
+      # split into named repositories if present
+      idx <- regexpr("=", parts, fixed = TRUE)
+      keys <- substring(parts, 1L, idx - 1L)
+      vals <- substring(parts, idx + 1L)
+      names(vals) <- keys
+  
+      # if we have a single unnamed repository, call it CRAN
+      if (length(vals) == 1L && identical(keys, ""))
+        names(vals) <- "CRAN"
+  
+      return(vals)
   
     }
   
@@ -508,6 +536,51 @@ local({
     }
   
     return(FALSE)
+  
+  }
+  
+  renv_bootstrap_find <- function(version) {
+  
+    path <- renv_bootstrap_find_cache(version)
+    if (length(path) && file.exists(path)) {
+      catf("- Using renv %s from global package cache", version)
+      return(path)
+    }
+  
+  }
+  
+  renv_bootstrap_find_cache <- function(version) {
+  
+    md5 <- attr(version, "md5", exact = TRUE)
+    if (is.null(md5))
+      return()
+  
+    # infer path to renv cache
+    cache <- Sys.getenv("RENV_PATHS_CACHE", unset = "")
+    if (!nzchar(cache)) {
+      root <- Sys.getenv("RENV_PATHS_ROOT", unset = NA)
+      if (!is.na(root))
+        cache <- file.path(root, "cache")
+    }
+  
+    if (!nzchar(cache)) {
+      tools <- asNamespace("tools")
+      if (is.function(tools$R_user_dir)) {
+        root <- tools$R_user_dir("renv", "cache")
+        cache <- file.path(root, "cache")
+      }
+    }
+  
+    # start completing path to cache
+    file.path(
+      cache,
+      renv_bootstrap_cache_version(),
+      renv_bootstrap_platform_prefix(),
+      "renv",
+      version,
+      md5,
+      "renv"
+    )
   
   }
   
@@ -979,7 +1052,7 @@ local({
   
   renv_bootstrap_validate_version_release <- function(version, description) {
     expected <- description[["Version"]]
-    is.character(expected) && identical(expected, version)
+    is.character(expected) && identical(c(expected), c(version))
   }
   
   renv_bootstrap_hash_text <- function(text) {
@@ -1179,6 +1252,18 @@ local({
   
     warning(paste(msg, collapse = "\n"), call. = FALSE)
   
+  }
+  
+  renv_bootstrap_cache_version <- function() {
+    # NOTE: users should normally not override the cache version;
+    # this is provided just to make testing easier
+    Sys.getenv("RENV_CACHE_VERSION", unset = "v5")
+  }
+  
+  renv_bootstrap_cache_version_previous <- function() {
+    version <- renv_bootstrap_cache_version()
+    number <- as.integer(substring(version, 2L))
+    paste("v", number - 1L, sep = "")
   }
   
   renv_json_read <- function(file = NULL, text = NULL) {


### PR DESCRIPTION
- renv 1.1.6 fixed a bug that led to unprotected renv cache folders/files, see [renv changelog](https://rstudio.github.io/renv/news/index.html#renv-116):
> Fixed an issue where cache callbacks (e.g. those run by setting RENV_CACHE_USER and RENV_CACHE_MODE, or via the renv.cache.callback option) were not run after [renv::hydrate()](https://rstudio.github.io/renv/reference/hydrate.html). ([#2179](https://github.com/rstudio/renv/issues/2179))